### PR TITLE
add go.mod: Pin discordgo version and support discordgo v0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ Examples:
 ### On Dedicated Host
 
 #### Clone & Install
-To run manually, clone this repositoy and install dependency:
+To run manually, clone this repository and build:
 ```
-go get github.com/bwmarrin/discordgo
 go build main.go
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module shuffle-bot
+
+go 1.13
+
+require github.com/bwmarrin/discordgo v0.22.0


### PR DESCRIPTION
This changes add go.mod to pin a version number of discordgo to v0.22.0, a latest version at the moment. This changes are intended to follow Discord API endpoint migration by updating underlying library version.

## Background
Our original version of shuffle-bot was based on discordgo v0.18.0. And our live version has been running on the same version for two years. However, Discord announced they will move API endpoint from this November. So we need to follow this breaking changes.

## Changes
- Assume discordgo v0.22.0
  - add go.mod to pin version
  - follow Discord API migration (requires later version of discordgo v0.21.0) ... closes #1
- Introduce some code changes
  - remove self-cache username
  - use `discordgo.Session.State` instead