### PR TITLE
Fix an unknown error while retrieving username

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,15 +114,21 @@ func messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 		var user *discordgo.User
 		member, err := s.State.Member(gid, vs.UserID)
-		if err == discordgo.ErrNilState || err == discordgo.ErrStateNotFound {
-			user, err = s.User(vs.UserID)
-			if err != nil {
-				fmt.Printf("Error while fetching username: %+v", err)
+		if err == nil {
+			user = member.User
+		} else {
+			if err == discordgo.ErrNilState || err == discordgo.ErrStateNotFound {
+				user, err = s.User(vs.UserID)
+				if err != nil {
+					fmt.Printf("Error while fetching username from API: %+v", err)
+					sendReply(s, m, "Error: temporary error.")
+					return
+				}
+			} else {
+				fmt.Printf("Error while fetching username from State: %+v", err)
 				sendReply(s, m, "Error: unknown error.")
 				return
 			}
-		} else {
-			user = member.User
 		}
 
 		if !isContain(user.Username, skipUsernames) {

--- a/main.go
+++ b/main.go
@@ -112,13 +112,18 @@ func messageHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 			sourceVoiceChannel = vs.ChannelID
 		}
 
+		var user *discordgo.User
 		member, err := s.State.Member(gid, vs.UserID)
-		if err != nil {
-			fmt.Println("Error while fetching username")
-			sendReply(s, m, "Error: unknown error.")
-			return
+		if err == discordgo.ErrNilState || err == discordgo.ErrStateNotFound {
+			user, err = s.User(vs.UserID)
+			if err != nil {
+				fmt.Printf("Error while fetching username: %+v", err)
+				sendReply(s, m, "Error: unknown error.")
+				return
+			}
+		} else {
+			user = member.User
 		}
-		user := member.User
 
 		if !isContain(user.Username, skipUsernames) {
 			voiceChannelUsers[vs.ChannelID] =


### PR DESCRIPTION
Renewed implementation watches only `discordgo.State` for retrieving username when user issues an `!!teams` command. This makes a problem and perhaps some users will experience some *unknown error* message. This error message causes when discordgo does not have State for a specific user yet.

This fix adds a fallback that queries Discord API to earn username when we have not cache in the State.